### PR TITLE
Customizing things

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -1,7 +1,7 @@
 ### PowerShell Profile Refactor
 ### Version 1.03 - Refactored
 
-$debug = $false
+$debug = $true
 
 if ($debug) {
     Write-Host "#######################################" -ForegroundColor Red
@@ -55,6 +55,8 @@ function Update-Profile {
     }
 }
 
+winfetch
+
 # skip in debug mode
 if (-not $debug) {
     Update-Profile
@@ -64,7 +66,7 @@ if (-not $debug) {
 
 function Update-PowerShell {
     try {
-        Write-Host "Checking for PowerShell updates..." -ForegroundColor Cyan
+        #Write-Host "Checking for PowerShell updates..." -ForegroundColor Cyan
         $updateNeeded = $false
         $currentVersion = $PSVersionTable.PSVersion.ToString()
         $gitHubApiUrl = "https://api.github.com/repos/PowerShell/PowerShell/releases/latest"
@@ -75,11 +77,11 @@ function Update-PowerShell {
         }
 
         if ($updateNeeded) {
-            Write-Host "Updating PowerShell..." -ForegroundColor Yellow
+            #Write-Host "Updating PowerShell..." -ForegroundColor Yellow
             Start-Process powershell.exe -ArgumentList "-NoProfile -Command winget upgrade Microsoft.PowerShell --accept-source-agreements --accept-package-agreements" -Wait -NoNewWindow
             Write-Host "PowerShell has been updated. Please restart your shell to reflect changes" -ForegroundColor Magenta
         } else {
-            Write-Host "Your PowerShell is up to date." -ForegroundColor Green
+            #Write-Host "Your PowerShell is up to date." -ForegroundColor Green
         }
     } catch {
         Write-Error "Failed to update PowerShell. Error: $_"

--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -131,12 +131,6 @@ function Test-CommandExists {
     return $exists
 }
 
-# Utility Functions
-function Test-CommandExists {
-    param($command)
-    $exists = $null -ne (Get-Command $command -ErrorAction SilentlyContinue)
-    return $exists
-}
 
 # Editor Configuration
 $EDITOR = if (Test-CommandExists code) { 'code' }
@@ -149,6 +143,7 @@ Set-Alias -Name vim -Value $EDITOR
 function Edit-Profile {
     vim $PROFILE.CurrentUserAllHosts
 }
+Set-Alias -Name ep -Value Edit-Profile
 
 function touch($file) { "" | Out-File $file -Encoding ASCII }
 function ff($name) {
@@ -160,9 +155,9 @@ function ff($name) {
 # Network Utilities
 function Get-PubIP { (Invoke-WebRequest http://ifconfig.me/ip).Content }
 
-# Open WinUtil pre-release
-function winutildev {
-	irm https://christitus.com/windev | iex
+# Open WinUtil full-release
+function winutil {
+	irm https://christitus.com/win | iex
 }
 
 # System Utilities

--- a/setup.ps1
+++ b/setup.ps1
@@ -68,7 +68,7 @@ if (!(Test-Path -Path $PROFILE -PathType Leaf)) {
     try {
         # Detect Version of PowerShell & Create Profile directories if they do not exist.
         $profilePath = ""
-        if ($PSVersionTable.PSEdition -eq "Core") { 
+        if ($PSVersionTable.PSEdition -eq "Core") {
             $profilePath = "$env:userprofile\Documents\Powershell"
         }
         elseif ($PSVersionTable.PSEdition -eq "Desktop") {
@@ -81,7 +81,7 @@ if (!(Test-Path -Path $PROFILE -PathType Leaf)) {
 
         Invoke-RestMethod https://github.com/JaviLendi/powershell-profile/raw/MyProfile/Microsoft.PowerShell_profile.ps1 -OutFile $PROFILE
         Write-Host "The profile @ [$PROFILE] has been created."
-        Write-Host "If you want to add any persistent components, please do so at [$profilePath\Profile.ps1] as there is an updater in the installed profile which uses the hash to update the profile and will lead to loss of changes"
+        Write-Host "If you want to make any personal changes or customizations, please do so at [$profilePath\Profile.ps1] as there is an updater in the installed profile which uses the hash to update the profile and will lead to loss of changes"
     }
     catch {
         Write-Error "Failed to create or update the profile. Error: $_"
@@ -90,7 +90,7 @@ if (!(Test-Path -Path $PROFILE -PathType Leaf)) {
 else {
     try {
         Get-Item -Path $PROFILE | Move-Item -Destination "oldprofile.ps1" -Force
-        Invoke-RestMethod https://github.com/JaviLendi/powershell-profile/raw/MyProfile/Microsoft.PowerShell_profile.ps1 -OutFile $PROFILE
+        Invoke-RestMethod https://github.com/JaviLendi/powershell-profile/raw/main/Microsoft.PowerShell_profile.ps1 -OutFile $PROFILE
         Write-Host "The profile @ [$PROFILE] has been created and old profile removed."
         Write-Host "Please back up any persistent components of your old profile to [$HOME\Documents\PowerShell\Profile.ps1] as there is an updater in the installed profile which uses the hash to update the profile and will lead to loss of changes"
     }


### PR DESCRIPTION
This pull request includes several changes to the `Microsoft.PowerShell_profile.ps1` and `setup.ps1` files. The most important changes include enabling debug mode, adding a new command, commenting out certain update messages, and updating URLs for fetching the profile script.

Changes to `Microsoft.PowerShell_profile.ps1`:

* Enabled debug mode by setting `$debug` to `$true`.
* Added the `winfetch` command to the profile.
* Commented out the `Write-Host` lines in the `Update-PowerShell` function to suppress update messages. [[1]](diffhunk://#diff-6a3cf8cae337c8ce108aa56ab5a133d64a409299287a0a4966f8e637c530eeaaL67-R69) [[2]](diffhunk://#diff-6a3cf8cae337c8ce108aa56ab5a133d64a409299287a0a4966f8e637c530eeaaL78-R84)
* Removed the `Test-CommandExists` function.
* Added an alias `ep` for the `Edit-Profile` function.
* Replaced the `winutildev` function with `winutil` to use the full-release URL.

Changes to `setup.ps1`:

* Updated the message to indicate where to make personal changes or customizations.
* Changed the URL for fetching the profile script to the main branch.