### PR TITLE
update

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -600,4 +600,7 @@ if (Test-Path "$PSScriptRoot\CTTcustom.ps1") {
     Invoke-Expression -Command "& `"$PSScriptRoot\CTTcustom.ps1`""
 }
 
+# Set UTF-8 encoding for the console
+[console]::InputEncoding = [console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
+
 Write-Host "$($PSStyle.Foreground.Yellow)Use 'Show-Help' to display help$($PSStyle.Reset)"


### PR DESCRIPTION
This pull request includes a small change to the `Microsoft.PowerShell_profile.ps1` file to set UTF-8 encoding for the console.

* [`Microsoft.PowerShell_profile.ps1`](diffhunk://#diff-6a3cf8cae337c8ce108aa56ab5a133d64a409299287a0a4966f8e637c530eeaaR603-R605): Added code to set UTF-8 encoding for both input and output in the console.